### PR TITLE
Update Travis, Appveyor and Coveralls badges url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,9 @@
 = MediTabs - Your preferred Medicine Stock Taking Application
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/cs2103-ay1819s2-t12-3/main[image:https://travis-ci.org/cs2103-ay1819s2-t12-3/main.svg?branch=master[Build Status]]
+https://travis-ci.org/CS2103-AY1819S2-T12-3/main[image:https://travis-ci.org/CS2103-AY1819S2-T12-3/main.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/JonathanLeeWH/main/branch/master[image:https://ci.appveyor.com/api/projects/status/voaxxqyrc7lauskt/branch/master?svg=true[Build status]]
-https://coveralls.io/github/cs2103-ay1819s2-t12-3/main?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
+https://coveralls.io/github/CS2103-AY1819S2-T12-3/main?branch=master[image:https://coveralls.io/repos/github/CS2103-AY1819S2-T12-3/main/badge.svg?branch=master[Coverage Status]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]


### PR DESCRIPTION
Update Travis, Appveyor and Coveralls badges url to match change in organisation url to be case sensitive

As stated in CS2103T module forum, the project list script requires organisation url to be change from `cs2103-ay1819s2-t12-3` to `CS2103-AY1819S2-T12-3`, this will result in having to change the Continuous Integration (CI) badges url such as Travis and Appveyor to match the new organisation url
Update Travis, Appveyor and Coveralls badges url to match change in organisation url to `CS2103-AY1819S2-T12-3`

Note: All organisation members should change their upstream remote url to `https://github.com/CS2103-AY1819S2-T12-3/main.git` to match the change in organisation url to be case sensitive as stated on CS2103T module forum