### PR TITLE
Improve UserGuide.adoc, DeveloperGuide.adoc and FileName.java

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -622,9 +622,9 @@ The specified file name *must not* be an empty string or `null`. If the specifie
 
 ==== How to integrate it into new commands in MediTabs?
 
-If you are a developer looking to add new features to MediTabs which involves the creation of files, we recommend integrating the existing `FileName` class. This can easily be done by making use of `FileName#isValidFileName(String fileNameToCheck)``. 
+If you are a developer looking to add new features to MediTabs which involves the creation of files, we recommend integrating the existing `FileName` class. This can easily be done by making use of `FileName#isValidFileName(String fileNameToCheck)`.
 
-You may wish to refer to the code snippet shown below, which is a modified version of the `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)`` operation used in MediTabs. The code snippet demonstrates how `FileName#isValidFileName(String fileNameToCheck)` can be used.
+You may wish to refer to the code snippet shown below, which is a modified version of the `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)` operation used in MediTabs. The code snippet demonstrates how `FileName#isValidFileName(String fileNameToCheck)` can be used.
 
 [source,java]
 ----

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -622,9 +622,9 @@ The specified file name *must not* be an empty string or `null`. If the specifie
 
 ==== How to integrate it into new commands in MediTabs?
 
-If you are a developer looking to improve MediTabs such as by adding new commands involving the creation of files, we recommend integrating the existing `FileName` class.
+If you are a developer looking to add new features to MediTabs which involves the creation of files, we recommend integrating the existing `FileName` class. This can easily be done by making use of `FileName#isValidFileName(String fileNameToCheck)``. 
 
-For example purposes, the code snippet shown below is a modified version of `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)` operation used in MediTabs for your reference:
+You may wish to refer to the code snippet shown below, which is a modified version of the `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)`` operation used in MediTabs. The code snippet demonstrates how `FileName#isValidFileName(String fileNameToCheck)` can be used.
 
 [source,java]
 ----

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -620,20 +620,20 @@ A full list of reserved names implemented in `FileName` class which are not allo
 [WARNING]
 The specified file name *must not* be an empty string or `null`. If the specified file name is an empty string, the specified file name will be declared as invalid. If the specified file name is `null`, a `NullPointerException` will be thrown.
 
-==== How to integrate it into your project or code?
+==== How to integrate it into new commands in MediTabs?
 
-If you are a developer looking to integrate `FileName` class into your project or code, we have provided a code snippet which provides you with an example of how to take advantage of the validation of file names provided by `FileName#isValidFileName(String fileNameToCheck)` operation.
+If you are a developer looking to improve MediTabs such as by adding new commands involving the creation of files, we recommend integrating the existing `FileName` class.
 
 For example purposes, the code snippet shown below is a modified version of `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)` operation used in MediTabs for your reference:
 
 [source,java]
 ----
 public static FileName parseFileName(String fileName) throws ParseException {
-        if (!FileName.isValidFileName(fileName)) { # <1>
-            throw new ParseException(FileName.MESSAGE_CONSTRAINTS); # <2>
-        }
-        return new FileName(fileName); # <3>
+    if (!FileName.isValidFileName(fileName)) { # <1>
+        throw new ParseException(FileName.MESSAGE_CONSTRAINTS); # <2>
     }
+    return new FileName(fileName); # <3>
+}
 ----
 <1> Validate the specified file name using the `FileName#isValidFileName(String fileNameToCheck)` operation.
 <2> If the specified file name is invalid, a `ParseException` is thrown.

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -622,9 +622,9 @@ The specified file name *must not* be an empty string or `null`. If the specifie
 
 ==== How to integrate it into new commands in MediTabs?
 
-If you are a developer looking to add new features to MediTabs which involves the creation of files, we recommend integrating the existing `FileName` class. This can easily be done by making use of `FileName#isValidFileName(String fileNameToCheck)`.
+If you are a developer looking to add new features to MediTabs which involves the creation of files, we recommend integrating the existing `FileName` class. This can easily be done by making use of `FileName#isValidFileName(String fileNameToCheck)` operation.
 
-You may wish to refer to the code snippet shown below, which is a modified version of the `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)` operation used in MediTabs. The code snippet demonstrates how `FileName#isValidFileName(String fileNameToCheck)` can be used.
+You may wish to refer to the code snippet shown below, which is a modified version of the `ParserUtil#parseFileName(String fileName, boolean isEmptyFileNameAllowed)` operation used in MediTabs. The code snippet demonstrates how `FileName#isValidFileName(String fileNameToCheck)` operation can be used for easier reference.
 
 [source,java]
 ----

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -496,7 +496,7 @@ MediTabs uses the following file naming convention when file name field is used 
 Format: `Start with an alphabet or number followed by alphabets, numbers, underscore or hyphen`
 
 [NOTE]
-File name *does not* include file extension such as `.csv` and `.pdf`. You do not have to include file extension when specifying the file name field such as in `export [File_NAME]`. MediTabs will handle the file name extension for you.
+File name *does not* include file extension such as `.csv` and `.pdf`. You do not have to include file extension when specifying the file name field such as in `export [FILE_NAME]`. MediTabs will handle the file name extension for you.
 
 Examples of correct and incorrect file names:
 |===

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -36,7 +36,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 2, 0, true);
+    public static final Version VERSION = new Version(1, 3, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/address/commons/util/FileName.java
+++ b/src/main/java/seedu/address/commons/util/FileName.java
@@ -28,9 +28,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class FileName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "File Names (without including file format) should only start with alphanumeric characters following "
-                    + "which can contain alphanumeric characters "
-                    + "or \"_\" or \"-\" (without quotation marks) and it should not be blank";
+            "File Name (without including file extension) must start with an alphabet or number followed by "
+                    + "alphabets, numbers, underscore or hyphen. It must not be a reserved word. "
+                    + "You can refer to the User Guide for more details.";
 
     /*
      * The characters of the file name must not contain any whitespace
@@ -70,7 +70,7 @@ public class FileName {
      */
     public static boolean isValidFileName(String fileNameToCheck) {
         requireNonNull(fileNameToCheck);
-        if (fileNameToCheck.isEmpty() || fileNameToCheck.matches(RESERVED_NAMES_REGEX)) {
+        if (fileNameToCheck.isEmpty() || fileNameToCheck.toUpperCase().matches(RESERVED_NAMES_REGEX)) {
             return false;
         }
         return fileNameToCheck.matches(VALIDATION_REGEX);

--- a/src/test/java/seedu/address/commons/util/FileNameTest.java
+++ b/src/test/java/seedu/address/commons/util/FileNameTest.java
@@ -53,6 +53,33 @@ public class FileNameTest {
         assertFalse(FileName.isValidFileName("LPT7"));
         assertFalse(FileName.isValidFileName("LPT8"));
         assertFalse(FileName.isValidFileName("LPT9"));
+        // Reserved names in lower case
+        assertFalse(FileName.isValidFileName("con"));
+        assertFalse(FileName.isValidFileName("prn"));
+        assertFalse(FileName.isValidFileName("aux"));
+        assertFalse(FileName.isValidFileName("nul"));
+        assertFalse(FileName.isValidFileName("com0"));
+        assertFalse(FileName.isValidFileName("com1"));
+        assertFalse(FileName.isValidFileName("com2"));
+        assertFalse(FileName.isValidFileName("com3"));
+        assertFalse(FileName.isValidFileName("com4"));
+        assertFalse(FileName.isValidFileName("com5"));
+        assertFalse(FileName.isValidFileName("com6"));
+        assertFalse(FileName.isValidFileName("com7"));
+        assertFalse(FileName.isValidFileName("com8"));
+        assertFalse(FileName.isValidFileName("com9"));
+        assertFalse(FileName.isValidFileName("lpt0"));
+        assertFalse(FileName.isValidFileName("lpt1"));
+        assertFalse(FileName.isValidFileName("lpt2"));
+        assertFalse(FileName.isValidFileName("lpt3"));
+        assertFalse(FileName.isValidFileName("lpt4"));
+        assertFalse(FileName.isValidFileName("lpt5"));
+        assertFalse(FileName.isValidFileName("lpt6"));
+        assertFalse(FileName.isValidFileName("lpt7"));
+        assertFalse(FileName.isValidFileName("lpt8"));
+        assertFalse(FileName.isValidFileName("lpt9"));
+        // Reserve names with a mix of lower and upper case
+        assertFalse(FileName.isValidFileName("CoM1"));
 
         // invalid file name
         assertFalse(FileName.isValidFileName("")); // empty string


### PR DESCRIPTION
Update DeveloperGuide.adoc language and description for Validation of File Name section proofread by @jtankw3. Credits to @jtankw3 for helping in improving the language used.
Update UserGuide.adoc formatting
Fix a bug in FileName.java where reserved names were allowed to be used if it is in lower case or a mixture of upper and lower case (which is not allowed in Windows based on personal testing)
Update FileNameTest.java to improve JUnit test case to match the changes to FileName.java
Update MediTabs version number to v1.3 to prepare for v1.3 milestone