### PR TITLE
Update DeveloperGuide.adoc based on review

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -20,7 +20,7 @@ By: `Team T12-3`      Since: `Feb 2019`      Licence: `MIT`
 // tag::introduction[]
 == Introduction
 
-Welcome to the _MediTabs Developer Guide_. You can find step by step instructions on how to set up MediTabs project on your computer and modify the project to suit your needs. You can also find out more about the development process of MediTabs such as its design and implementation. Interested? You can jump to <<Setting Up>> to get started. Enjoy!
+Welcome to the _MediTabs Developer Guide_. You can find step by step instructions on how to set up MediTabs project on your computer and modify the project to suit your needs. You can also find out more about the development process of MediTabs such as its design and implementation. Interested? You can jump to <<Setting up>> to get started. Enjoy!
 
 === What is MediTabs
 

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -26,7 +26,7 @@ Welcome to the _MediTabs Developer Guide_. You can find step by step instruction
 
 MediTabs is a desktop application, developed using Java, for managing medicine stock taking. You can use MediTabs in your clinics to easily keep track of your medicine inventory and take note of important information such as which medicines are low in stock, expiring soon or have expired.
 
-MediTabs supports Windows, Linux and MacOS operating systems.
+MediTabs supports Windows, Linux and macOS operating systems.
 
 === Who is this guide for?
 
@@ -621,11 +621,11 @@ File name *does not* include file extension such as `.csv` and `.pdf`.
 
 A list of reasons why we choose to create a `FileName` class for the validation of file name:
 
-* There are currently no third party libraries available for validating file name to ensure that the file name is platform independent. In other words, there are no public methods to validate the file name specified by the user to ensure that it is supported on Windows, Linux and MacOS operating systems.
+* There are currently no third party libraries available for validating file name to ensure that the file name is platform independent. In other words, there are no public methods to validate the file name specified by the user to ensure that it is supported on Windows, Linux and macOS operating systems.
 [IMPORTANT]
-There are certain naming conventions which have to be followed on Windows operating system which are not necessary on Linux and MacOS operating systems. You can read more about the naming conventions for Windows link:https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#naming-conventions[here]. You can also refer to link:https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations[this] Wikipedia article for a detailed comparison between different naming conventions for different operating systems.
+There are certain naming conventions which have to be followed on Windows operating system which are not necessary on Linux and macOS operating systems. You can read more about the naming conventions for Windows link:https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#naming-conventions[here]. You can also refer to link:https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations[this] Wikipedia article for a detailed comparison between different naming conventions for different operating systems.
 * Ensure consistency by creating a file naming convention.
-* Ensure that files created with file names specified by the user can be used on Windows, Linux and MacOS operating systems. This is to avoid potential bugs involving file names as MediTabs supports Windows, Linux and MacOS operating systems hence, the user might switch between these operating systems when using MediTabs.
+* Ensure that files created with file names specified by the user can be used on Windows, Linux and macOS operating systems. This is to avoid potential bugs involving file names as MediTabs supports Windows, Linux and macOS operating systems hence, the user might switch between these operating systems when using MediTabs.
 
 ==== Current Implementation
 
@@ -1043,7 +1043,7 @@ Use case resume at step 2.
 == Glossary
 
 [[mainstream-os]] Mainstream OS::
-Windows, Linux, Unix, OS-X
+Windows, Linux, Unix, macOS
 
 [[inventory]] Inventory::
 A complete list of goods in stock
@@ -1051,23 +1051,6 @@ A complete list of goods in stock
 [[batch]] Batch::
 A quantity or consignment of goods produced at one time
 
-
-[appendix]
-== Product Survey
-
-*Product Name*
-
-Author: ...
-
-Pros:
-
-* ...
-* ...
-
-Cons:
-
-* ...
-* ...
 
 [appendix]
 == Instructions for Manual Testing

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -327,7 +327,7 @@ If the default `exported` directory is not found, it will be automatically creat
 [NOTE]
 Out of the three key operations stated above, *only* `CsvWrapper#export()` is a _public_ operation available for use by other components. It acts as the main interface which other components use to interact with `CsvWrapper` in order to integrate exporting to CSV file format feature into their own implementation.
 
-Given below is a sequence diagram overview of how these 3 key operations behaves when the user executes the `export` command in order to export the current medicine inventory data shown in the GUI to CSV file format:
+Given below is a sequence diagram overview of how these 3 key operations behave when the user executes the `export` command in order to export the current medicine inventory data shown in the GUI to CSV file format:
 
 .Export Command Sequence Diagram Overview
 image::ExportCommandSequenceDiagramOverview.png[width="800"]
@@ -365,7 +365,7 @@ image::ExportCommandActivityDiagram.png[width="800"]
 * **Alternative 1 (current choice):** Exports the current medicine inventory data shown in the GUI to CSV file format using the `export` command.
 ** Pros: Easy to implement and users can preview the data before exporting.
 ** Cons: May have performance issues in terms of memory usage.
-* **Alternative 2:** Individual commands can add an additional `export` parameter to support exporting as CSV file.
+* **Alternative 2:** Individual commands can add an additional `export` parameter to support exporting as CSV file format.
 ** Pros: Users can export directly through individual commands which support the additional `export` parameter (e.g. The `find` command with its additional `export` parameter set to true, exports the filtered medicine inventory data immediately without having to retrieve from `Model#getFilteredMedicineList()` operation).
 ** Cons: We must ensure that the implementation and integration of the exporting to CSV file of each individual commands are correct. Furthermore, users are not able to preview the data before exporting.
 
@@ -375,7 +375,7 @@ image::ExportCommandActivityDiagram.png[width="800"]
 ** Pros: Easy for developers to understand, especially for those who want to modify the way in which the data is organised when exported to CSV file format but have no prior knowledge on `Opencsv` Java CSV parser library.
 ** Cons: The time complexity of the algorithm is O(n) and might not be as efficient especially when a large amount of data is involved. Furthermore, it does not take full advantage of the more advanced features provided by the `Opencsv` Java CSV parser library.
 * **Alternative 2:** Use `Opencsv` Java CSV parser library's `StatefulBeanToCsvBuilder` operation for building the structure in which the data is organised from the list retrieved using the `Model#getFilterMedicineList()` operation when exporting to CSV file format.
-** Pros: Does not require iterating through the list and convert it to a String Array as we can use the library's `StatefulBeanToCsvBuilder` operation to build the structure from the list by passing the list as a parameter to the operation. Furthermore, the formatting process can be automated using the operation. It is also more efficient in terms of performance according to the library's documentation if ordering of the data exported is not a concern to the developer.
+** Pros: Does not require iterating through the list and convert it to a String Array as we can use the library's `StatefulBeanToCsvBuilder` operation to build the structure from the list by passing the list as a parameter to the operation. Furthermore, the formatting process can be automated using the operation. It is also more efficient in terms of performance according to the library's documentation if the ordering of the data exported is not a concern to the developer.
 ** Cons: Requires prior knowledge on the way in which the library's `StatefulBeanToCsvBuilder` operation works. If a developer wants to modify the data exported to be ordered in a specific format, it requires knowledge on the library's `MappingStrategy` related operations which may be complicated for developers new to the library.
 [NOTE]
 More information on `Opencsv` library's `StatefulBeanToCsvBuilder` operation can be found in the library's link:http://opencsv.sourceforge.net/[documentation].

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -171,7 +171,7 @@ Benefits of integration addon support are as follows:
 
 An example of an integration addon which would be supported by MediTabs:
 
-* Singapore's Health Science Authority (HSA) - To integrate the Singapore HSA's medical database with MediTabs which allows easy retrieval of important information such as when a medicine is requested to be recalled by the HSA.
+* Singapore's Health Science Authority (HSA) - To integrate the Singapore HSA's medical database with MediTabs which allows easy retrieval of important information such as when medicine is requested to be recalled by the HSA.
 
 [NOTE]
 This feature can be improved to support medical databases of different countries.
@@ -427,7 +427,7 @@ If a file with the specified file name already exists in the default `exported` 
 
 A sample image of how the medicine inventory data in the exported CSV file is organised:
 
-.Sample of exported CSV file
+.Sample of the exported CSV file
 image::SampleCSVFileImage.png[width="790"]
 
 [NOTE]

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -25,7 +25,7 @@ Welcome to the _MediTabs User Guide_! Over here, you can find step by step instr
 
 MediTabs is a desktop application for managing medicine stock taking. You can use MediTabs in your clinics to easily keep track of your medicine inventory and take note of important information such as which medicines are low in stock, expiring soon or have expired.
 
-MediTabs supports Windows, Linux and MacOS operating systems.
+MediTabs supports Windows, Linux and macOS operating systems.
 
 === Who is it for?
 
@@ -124,7 +124,7 @@ You can learn about related commands related in <<WarningPanel>>.
 // tag::exportingascsvfileformat[]
 === Exporting as CSV file format
 
-You can export the current medicine inventory data shown in the GUI as Comma-separated values (CSV) file format which is supported by many commonly used spreadsheet applications such as Microsoft Excel (Windows), LibreOffice (Linux) or Numbers (MacOS).
+You can export the current medicine inventory data shown in the GUI as Comma-separated values (CSV) file format which is supported by many commonly used spreadsheet applications such as Microsoft Excel (Windows), LibreOffice (Linux) or Numbers (macOS).
 
 *Motivation* +
 This feature is especially useful if you want to save the current medicine inventory data shown in the GUI in a file so that it can be printed later or if you want to organise the medicine inventory data using a spreadsheet application for you, your superior or your supplier's reference.
@@ -632,7 +632,7 @@ e.g. `warning e/20`, `warning s/10`, `warning show`
 // tag::filenamingconvention[]
 == Appendix A: File Naming Convention
 
-MediTabs uses the following file naming convention when file name field is used e.g. The `export` command's optional `[FILE_NAME]` field. The file naming convention is to ensure consistency and to avoid potential bugs involving file names with different operating systems such as Windows, Linux and MacOS +
+MediTabs uses the following file naming convention when file name field is used e.g. The `export` command's optional `[FILE_NAME]` field. The file naming convention is to ensure consistency and to avoid potential bugs involving file names with different operating systems such as Windows, Linux and macOS +
 Format: `Start with an alphabet or number followed by alphabets, numbers, underscore or hyphen`
 
 [NOTE]

--- a/docs/team/jonathanleewh.adoc
+++ b/docs/team/jonathanleewh.adoc
@@ -48,7 +48,7 @@ This section highlights my documentation, coding and other noteworthy contributi
 
 ** Project management:
 *** Set up team project GitHub repository including setting up issue tracker, permissions, project page, milestones and labels.
-*** Managed releases `v1.1` - `v1.4` (7 releases) on GitHub
+*** Managed releases `v1.1` - `v1.4` (9 releases) on GitHub
 ** Documentation:
 *** Added Introduction sections to both User Guide and Developer Guide: https://github.com/CS2103-AY1819S2-T12-3/main/pull/115[#115], https://github.com/CS2103-AY1819S2-T12-3/main/pull/140[#140]
 *** Added Frequently Asked Question (FAQ) and File Naming Convention sections to User Guide: https://github.com/CS2103-AY1819S2-T12-3/main/pull/123[#123], https://github.com/CS2103-AY1819S2-T12-3/main/pull/135[#135]

--- a/docs/team/jonathanleewh.adoc
+++ b/docs/team/jonathanleewh.adoc
@@ -4,13 +4,13 @@
 :stylesDir: ../stylesheets
 
 == Introduction
-Welcome to my Project Portfolio which provides you with an overview of my technical skills in the writing of documentations, coding and other contributions to my team project, *MediTabs*, for a Software Engineering module in the National University of Singapore (NUS).
+Welcome to my Project Portfolio which provides you with an overview of my technical skills in the writing of documentation, coding and other contributions to my team project, *MediTabs*, for a Software Engineering module in the National University of Singapore (NUS).
 
 == About the project
 
 The team project involved improving an existing link:https://github.com/nus-cs2103-AY1819S2/addressbook-level4/[Addressbook application] for users who prefer command line interfaces (CLI). My team and I chose to morph it into a medicine inventory management application called *MediTabs*. The goal is to streamline the medicine inventory management workflow in clinics by enabling pharmacists to keep track and manage medicine inventory easily; export the data for easier reference and data analysis; and print medicine labels containing essential medicine information.
 
-I am the team lead and is in charge of designing and implementing the `export` feature.
+I am the team leader and in charge of designing and implementing the `export` feature.
 
 This document uses the following labels and formatting:
 
@@ -40,20 +40,20 @@ This section highlights my documentation, coding and other noteworthy contributi
 ** Highlights: This enhancement requires an indepth understanding of how each major components work and the methods available as it involves retrieving of data from the GUI and parsing the retrieved data. Despite using the Opencsv library, the implementation was still challenging as it required using methods from different components, parsing and organising the data such that the exported file contains only the essential information for easier reference.
 ** Credits: link:http://opencsv.sourceforge.net/team.html[Opencsv Team]
 
-* *Minor enhancement*: As there are currently no third party libraries available which validates file name such that it adheres to the file naming conventions of the major operating systems (OS), I have created a `FileName` class which implements this feature to complement the `export` feature and is also used by the `label` feature. It requires an indepth knowledge on the different file naming conventions of the various OS and also numerous testing as I discovered that some file name conventions were not documented and not allowed to be used as file names.
+* *Minor enhancement*: As there are currently no third party libraries available which validate file name such that it adheres to the file naming conventions of the major operating systems (OS), Windows, Linux and macOS, I have created a `FileName` class which implements this feature to complement the `export` feature and is also used by the `label` feature. It requires an indepth knowledge of the different file naming conventions used in the various OS and also numerous testing as I discovered that some file name conventions were not documented and not allowed to be used as file names.
 
 * *Code contributed*: https://nus-cs2103-ay1819s2.github.io/cs2103-dashboard/#=undefined&search=jonathanleewh[Project Code Dashboard]
 
 * *Other contributions*:
 
 ** Project management:
-*** Set up team project GitHub repository including setting up issue tracker, permissions, project page, milestones and labels.
+*** Set up team project GitHub repository including setting up the issue tracker, permissions, project page, milestones and labels.
 *** Managed releases `v1.1` - `v1.4` (9 releases) on GitHub
 ** Documentation:
 *** Added Introduction sections to both User Guide and Developer Guide: https://github.com/CS2103-AY1819S2-T12-3/main/pull/115[#115], https://github.com/CS2103-AY1819S2-T12-3/main/pull/140[#140]
 *** Added Frequently Asked Question (FAQ) and File Naming Convention sections to User Guide: https://github.com/CS2103-AY1819S2-T12-3/main/pull/123[#123], https://github.com/CS2103-AY1819S2-T12-3/main/pull/135[#135]
 *** Added Validation of File Name section to Developer Guide which includes code snippet for reference on how to take advantage of the `FileName` class provided: https://github.com/CS2103-AY1819S2-T12-3/main/pull/140[#140]
-*** Update stylesheet to PDF printing friendly format: https://github.com/CS2103-AY1819S2-T12-3/main/pull/150[#150]
+*** Update stylesheet to PDF printer friendly format: https://github.com/CS2103-AY1819S2-T12-3/main/pull/150[#150]
 *** Updated User Guide's Quick Start section and Developer Guide's Setting Up section to only allow Java version `9` and JDK `9` including references to the reason for the change: https://github.com/CS2103-AY1819S2-T12-3/main/pull/117[#117], https://github.com/CS2103-AY1819S2-T12-3/main/pull/123[#123]
 *** Updated User Guide Quick Start section with an additional step on how users can seek assistance: https://github.com/CS2103-AY1819S2-T12-3/main/pull/115[#115]
 *** Updated Storage component class diagram of Developer Guide to match our project: https://github.com/CS2103-AY1819S2-T12-3/main/pull/79[#79]


### PR DESCRIPTION
Update DeveloperGuide.adoc based on review
Fix link in Introduction section
Remove {more test cases ...} from deleting a medicine section as suggested in the review
Remove the product survey section as we did not use it
Update wording for consistency `MacOS` to `macOS` as the official name is `macOS` with the letter `m` being a small letter
Update Glossary section to ensure consistency
Note: I did not change the part involving export command which was commented by the tutor in the review as I have discussed with the tutor and he stated it is accepted as it was stated in the website that object deletion can have an arrow indicating delete. I also did not change the `How to integrate...` as after discussing with the tutor he stated it is also accepted as it is also friendly and it also coincides with the introduction as it speaks directly to the developers