### PR TITLE
Change order of medicine card fields

### DIFF
--- a/src/main/java/seedu/address/commons/core/InformationPanelSettings.java
+++ b/src/main/java/seedu/address/commons/core/InformationPanelSettings.java
@@ -62,9 +62,9 @@ public class InformationPanelSettings {
          * Returns true if a given string is a valid sort property.
          */
         public static boolean isValidSortProperty(String sortProperty) {
-            return sortProperty.toUpperCase().equals("BATCHNUMBER")
-                    || sortProperty.toUpperCase().equals("QUANTITY")
-                    || sortProperty.toUpperCase().equals("EXPIRY");
+            return sortProperty.equalsIgnoreCase(BATCHNUMBER.toString())
+                    || sortProperty.equalsIgnoreCase(QUANTITY.toString())
+                    || sortProperty.equalsIgnoreCase(EXPIRY.toString());
         }
 
         @Override
@@ -85,8 +85,8 @@ public class InformationPanelSettings {
          * Returns true if a given string is a valid sort direction.
          */
         public static boolean isValidSortDirection(String sortDirection) {
-            return sortDirection.toUpperCase().equals("ASCENDING")
-                    || sortDirection.toUpperCase().equals("DESCENDING");
+            return sortDirection.equalsIgnoreCase(ASCENDING.toString())
+                    || sortDirection.equalsIgnoreCase(DESCENDING.toString());
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -193,18 +193,17 @@ public class ParserUtil {
     public static SortProperty parseSortProperty(String sortProperty) throws ParseException {
         requireNonNull(sortProperty);
         String trimmedProperty = sortProperty.trim();
-        if (!SortProperty.isValidSortProperty(sortProperty)) {
+        if (!SortProperty.isValidSortProperty(trimmedProperty)) {
             throw new ParseException(SortProperty.MESSAGE_CONSTRAINTS);
         }
 
-        sortProperty = trimmedProperty.toLowerCase();
-        if (sortProperty.equals(SortProperty.BATCHNUMBER.toString())) {
+        if (trimmedProperty.equalsIgnoreCase(SortProperty.BATCHNUMBER.toString())) {
             return SortProperty.BATCHNUMBER;
         }
-        if (sortProperty.equals(SortProperty.QUANTITY.toString())) {
+        if (trimmedProperty.equalsIgnoreCase(SortProperty.QUANTITY.toString())) {
             return SortProperty.QUANTITY;
         }
-        if (sortProperty.equals(SortProperty.EXPIRY.toString())) {
+        if (trimmedProperty.equalsIgnoreCase(SortProperty.EXPIRY.toString())) {
             return SortProperty.EXPIRY;
         }
         throw new ParseException("Unknown sort property");
@@ -219,15 +218,14 @@ public class ParserUtil {
     public static SortDirection parseSortDirection(String sortDirection) throws ParseException {
         requireNonNull(sortDirection);
         String trimmedDirection = sortDirection.trim();
-        if (!SortDirection.isValidSortDirection(sortDirection)) {
+        if (!SortDirection.isValidSortDirection(trimmedDirection)) {
             throw new ParseException(SortDirection.MESSAGE_CONSTRAINTS);
         }
 
-        sortDirection = trimmedDirection.toLowerCase();
-        if (sortDirection.equals(SortDirection.ASCENDING.toString())) {
+        if (trimmedDirection.equalsIgnoreCase(SortDirection.ASCENDING.toString())) {
             return SortDirection.ASCENDING;
         }
-        if (sortDirection.equals(SortDirection.DESCENDING.toString())) {
+        if (trimmedDirection.equalsIgnoreCase(SortDirection.DESCENDING.toString())) {
             return SortDirection.DESCENDING;
         }
         throw new ParseException("Unknown sort direction");

--- a/src/main/java/seedu/address/ui/MedicineCard.java
+++ b/src/main/java/seedu/address/ui/MedicineCard.java
@@ -23,9 +23,9 @@ public class MedicineCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label quantity;
-    @FXML
     private Label company;
+    @FXML
+    private Label quantity;
     @FXML
     private Label expiry;
     @FXML
@@ -36,8 +36,8 @@ public class MedicineCard extends UiPart<Region> {
         this.medicine = medicine;
         id.setText(displayedIndex + ". ");
         name.setText(medicine.getName().fullName);
-        quantity.setText(medicine.getTotalQuantity().toString());
         company.setText(medicine.getCompany().companyName);
+        quantity.setText(medicine.getTotalQuantity().toString());
         expiry.setText(medicine.getNextExpiry().toString());
         medicine.getTags().forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }

--- a/src/main/resources/view/MedicineListCard.fxml
+++ b/src/main/resources/view/MedicineListCard.fxml
@@ -27,10 +27,14 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="tags" />
-      <Label fx:id="quantity" styleClass="cell_small_label" text="\$quantity" />
       <Label fx:id="company" styleClass="cell_small_label" text="\$company" />
+      <Label fx:id="quantity" styleClass="cell_small_label" text="\$quantity" />
       <Label fx:id="expiry" styleClass="cell_small_label" text="\$expiry" />
+      <FlowPane fx:id="tags" alignment="CENTER_LEFT">
+        <padding>
+          <Insets top="3" bottom="1" />
+        </padding>
+      </FlowPane>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/guitests/guihandles/StageHandle.java
+++ b/src/test/java/guitests/guihandles/StageHandle.java
@@ -38,9 +38,9 @@ public abstract class StageHandle {
      */
     public void focus() {
         String windowTitle = stage.getTitle();
-        logger.info("Focusing on" + windowTitle);
+        logger.info("Focusing on " + windowTitle);
         guiRobot.interact(stage::requestFocus);
-        logger.info("Finishing focus on" + windowTitle);
+        logger.info("Finishing focus on " + windowTitle);
     }
 
     /**


### PR DESCRIPTION
Move up company field in medicine card as it is a vital identifier.
Move down tags to prevent mess when longs tags or multiple tags are added. 