### PR TITLE
Improve documentation

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -1105,6 +1105,14 @@ _{ more test cases ... }_
 
 === Exporting as CSV file format
 
+. Exporting the current medicine inventory data shown in the GUI to CSV file format while all medicines are listed.
+
+.. Prerequisites: List all medicines using the `list` command.
+.. Test case: `export \` +
+Expected: An "Invalid command format! File Name (without including file extension) must start with an alphabet or number followed by alphabets, numbers, underscore or hyphen. It must not be a reserved word. You can type the help command to view the User Guide for more details. +
+export: exports the current list to a .csv file. Parameters: [FILE_NAME] +
+Example: export example" exception will be shown in the `ResultDisplay` panel of the GUI. *No* exported CSV file is created in the `exported` directory.
+
 . Exporting the current medicine inventory data shown in the GUI to CSV file format while all medicines are listed. There are *no cases* where there are no medicines or all medicines do not have batches in the current medicine inventory data shown in the GUI.
 
 .. Prerequisites: List all medicines using the `list` command. Multiple medicines *with batches* are in the list.

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -1103,6 +1103,26 @@ Expected: Similar to previous.
 
 _{ more test cases ... }_
 
+=== Exporting as CSV file format
+
+. Exporting the current medicine inventory data shown in the GUI to CSV file format while all medicines are listed. There are *no cases* where there are no medicines or all medicines do not have batches in the current medicine inventory data shown in the GUI.
+
+.. Prerequisites: List all medicines using the `list` command. Multiple medicines *with batches* are in the list.
+.. Test case: `export` +
+Expected: The current medicine inventory data shown in the GUI is successfully exported to CSV file format. The exported CSV file has the default file name based on the date and time of export. The specific date and time format used if no file name is specified is `dd_MMM_yyyy_HH_mm_ss` e.g. `18_Mar_2019_10_28_00`. The exported CSV file's medicine inventory data will contain the header information with *only* the data of medicines with batches.
+.. Test case: `export example` +
+Expected: The current medicine inventory data shown in the GUI is successfully exported to CSV file format. The exported CSV file has the file name `example`. The exported CSV file's medicine inventory data will contain the header information with *only* the data of medicines with batches.
+
+. Exporting the current medicine inventory data shown in the GUI to CSV file format while all medicines are listed. There are either no medicines or all medicines do not have batches in the current medicine inventory data shown in the GUI.
+
+.. Prerequisites: List all medicines using the `list` command. No medicines or all medicines do not have batches in the current medicine inventory data.
+.. Test case: `export` +
+Expected: The current medicine inventory data shown in the GUI is successfully exported to CSV file format. The exported CSV file has the default file name based on the date and time of export. The specific date and time format used if no file name is specified is `dd_MMM_yyyy_HH_mm_ss` e.g. `18_Mar_2019_10_28_00`. The exported CSV file's medicine inventory data will contain *only* the header information with no medicine data.
+.. Test case: `export example` +
+Expected: The current medicine inventory data shown in the GUI is successfully exported to CSV file format. The exported CSV file has the file name `example`. The exported CSV file's medicine inventory data will contain *only* the header information with no medicine data.
+
+_{ more test cases ... }_
+
 === Saving data
 
 . Dealing with missing/corrupted data files

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -422,7 +422,7 @@ Format: `export [FILE_NAME]`
 ****
 * The `FILE_NAME` field is optional. You can refer to <<Appendix A: File Naming Convention>> for supported file name format if you want to specify a file name for the exported CSV file.
 * If no file name is specified, the `export` command uses the default file name format according to the date and time of export.
-* The specific data and time format used if no file name is specified is `dd_MMM_yyyy_HH_mm_ss` e.g. `18_Mar_2019_10_28_00`
+* The specific date and time format used if no file name is specified is `dd_MMM_yyyy_HH_mm_ss` e.g. `18_Mar_2019_10_28_00`
 * The file extension for a CSV file is `.csv`
 * The exported file can be found in the default `exported` folder which can be found in the home folder used for your MediTabs application.
 * If the default `exported` folder is not found in the home folder, MediTabs will automatically create the folder when the `export` command is executed.

--- a/src/main/java/seedu/address/commons/util/csv/CsvWrapper.java
+++ b/src/main/java/seedu/address/commons/util/csv/CsvWrapper.java
@@ -36,10 +36,10 @@ public class CsvWrapper {
     public static final String DEFAULT_EXPIRING_SOON_NOTIFICATION = "[EXPIRING SOON]";
     public static final String DEFAULT_EXPIRED_NOTIFICATION = "[EXPIRED]";
     public static final String DEFAULT_LOW_STOCK_NOTIFICATION = "[LOW STOCK]";
-    // The reason for the limitation to 255 characters for file name is due to the limitations
+    // The reason for the limitation of maximum 255 characters for file name is due to the limitations
     // set by Windows (MAX_PATH limitation
-    // in Windows https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
-    // and also different file systems supports up to different characters.
+    // in Windows https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation)
+    // and also different file systems support up to different number of characters.
     // There is no universal way of solving this problem to
     // allow portability between different operating systems such as Windows, Linux and macOS due to this limitation,
     // hence based on the comparison charts and most common length limitation shown in the comparison chart in

--- a/src/main/java/seedu/address/commons/util/csv/CsvWrapper.java
+++ b/src/main/java/seedu/address/commons/util/csv/CsvWrapper.java
@@ -36,6 +36,16 @@ public class CsvWrapper {
     public static final String DEFAULT_EXPIRING_SOON_NOTIFICATION = "[EXPIRING SOON]";
     public static final String DEFAULT_EXPIRED_NOTIFICATION = "[EXPIRED]";
     public static final String DEFAULT_LOW_STOCK_NOTIFICATION = "[LOW STOCK]";
+    // The reason for the limitation to 255 characters for file name is due to the limitations
+    // set by Windows (MAX_PATH limitation in Windows https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+    // and also different file systems supports up to different characters.
+    // There is no universal way of solving this problem to
+    // allow portability between different operating systems such as Windows, Linux and macOS due to this limitation,
+    // hence based on the comparison charts and most common length limitation shown in the comparison chart in
+    // https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations, the MAX_FILE_NAME_LENGTH is
+    // set to 255 though it might not be a method to solve portability of file name length completely but it is
+    // a general agreed limit by programmers when programming to set the file name to 255 characters.
+    public static final int MAX_FILE_NAME_LENGTH = 255;
     private static String[] defaultHeading = {"Name", "Batch Number", "Quantity", "Expiry Date", "Company", "Tags",
                                               "Notifications"};
     private static final String DEFAULT_EXPORT_FOLDER_NAME = "exported";
@@ -75,6 +85,13 @@ public class CsvWrapper {
     private void createCsvFile(String csvFileName) throws CommandException {
         createIfExportDirectoryMissing();
         try {
+            if (csvFileName.length() > MAX_FILE_NAME_LENGTH) {
+                throw new CommandException((FILE_OPS_ERROR_MESSAGE + "The file name is too long, try to reduce"
+                        + " the specified file name length to be within 255 characters.\n"
+                        + "Note: This is just a standardise file name length and a FileSystemException exception might"
+                        + " still occur during file creation depending on your current"
+                        + " operating system's file system."));
+            }
             csvFilePath = Files.createFile(Paths.get(DEFAULT_EXPORT_FOLDER_NAME, csvFileName + ".csv"));
         } catch (FileAlreadyExistsException fae) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + csvFileName + ".csv" + " already exists in \""

--- a/src/main/java/seedu/address/commons/util/csv/CsvWrapper.java
+++ b/src/main/java/seedu/address/commons/util/csv/CsvWrapper.java
@@ -37,7 +37,8 @@ public class CsvWrapper {
     public static final String DEFAULT_EXPIRED_NOTIFICATION = "[EXPIRED]";
     public static final String DEFAULT_LOW_STOCK_NOTIFICATION = "[LOW STOCK]";
     // The reason for the limitation to 255 characters for file name is due to the limitations
-    // set by Windows (MAX_PATH limitation in Windows https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+    // set by Windows (MAX_PATH limitation
+    // in Windows https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
     // and also different file systems supports up to different characters.
     // There is no universal way of solving this problem to
     // allow portability between different operating systems such as Windows, Linux and macOS due to this limitation,


### PR DESCRIPTION
Update `CsvWrapper.java` with a check for maximum specified file name length based on the user's current operating system or it will default to `255` character limit for file name which is the general convention by programmers
Update `UserGuide.adoc` export command description
Update `DeveloperGuide.adoc` with sample test cases and expected outputs for the various test cases for the export command under Instructions for Manual Testing section